### PR TITLE
FEAT: support lark message

### DIFF
--- a/ironfish-cli/src/commands/miners/pools/start.ts
+++ b/ironfish-cli/src/commands/miners/pools/start.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_POOL_HOST,
   DEFAULT_POOL_PORT,
   Discord,
+  Lark,
   MiningPool,
   parseUrl,
   StringUtils,
@@ -22,6 +23,10 @@ export class StartPool extends IronfishCommand {
     discord: Flags.string({
       char: 'd',
       description: 'a discord webhook URL to send critical information to',
+    }),
+    lark: Flags.string({
+      char: 'l',
+      description: 'a lark webhook URL to send critical information to',
     }),
     host: Flags.string({
       char: 'h',
@@ -66,6 +71,18 @@ export class StartPool extends IronfishCommand {
       this.log(`Discord enabled: ${discordWebhook}`)
     }
 
+    let lark: Lark | undefined = undefined
+
+    const larkWebhook = flags.lark ?? this.sdk.config.get('poolLarkWebhook')
+    if (larkWebhook) {
+      lark = new Lark({
+        webhook: larkWebhook,
+        logger: this.logger,
+      })
+
+      this.log(`Lark enabled: ${larkWebhook}`)
+    }
+
     let host = undefined
     let port = undefined
 
@@ -87,6 +104,7 @@ export class StartPool extends IronfishCommand {
       rpc,
       enablePayouts: flags.payouts,
       discord,
+      lark,
       host: host,
       port: port,
     })

--- a/ironfish/src/fileStores/config.ts
+++ b/ironfish/src/fileStores/config.ts
@@ -189,6 +189,11 @@ export type ConfigOptions = {
    * The discord webhook URL to post pool critical pool information too
    */
   poolDiscordWebhook: ''
+
+  /**
+   * The lark webhook URL to post pool critical pool information too
+   */
+  poolLarkWebhook: ''
 }
 
 export const ConfigOptionsSchema: yup.ObjectSchema<Partial<ConfigOptions>> = yup
@@ -264,6 +269,7 @@ export class Config extends KeyStore<ConfigOptions> {
       poolSuccessfulPayoutInterval: DEFAULT_POOL_SUCCESSFUL_PAYOUT_INTERVAL,
       poolRecentShareCutoff: DEFAULT_POOL_RECENT_SHARE_CUTOFF,
       poolDiscordWebhook: '',
+      poolLarkWebhook: '',
     }
   }
 }

--- a/ironfish/src/mining/index.ts
+++ b/ironfish/src/mining/index.ts
@@ -4,6 +4,7 @@
 
 export { MiningManager } from './manager'
 export { Discord } from './discord'
+export { Lark } from './lark'
 export { MiningPool } from './pool'
 export { MiningPoolMiner } from './poolMiner'
 export { MiningSoloMiner } from './soloMiner'

--- a/ironfish/src/mining/lark.ts
+++ b/ironfish/src/mining/lark.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import Axios, { AxiosInstance } from 'axios'
+import { createRootLogger, Logger } from '../logger'
+import { displayIronAmountWithCurrency, ErrorUtils, oreToIron } from '../utils'
+import { FileUtils } from '../utils/file'
+
+export class Lark {
+  private readonly webhook: string | null = null
+  private readonly client: AxiosInstance | null = null
+  private readonly logger: Logger
+
+  constructor(options: { webhook: string | null; logger?: Logger }) {
+    this.logger = options.logger ?? createRootLogger()
+
+    if (options.webhook) {
+      this.webhook = options.webhook
+      this.client = Axios.create()
+    }
+  }
+
+  sendText(text: string): void {
+    if (!this.client || !this.webhook) {
+      return
+    }
+
+    this.client.post(this.webhook, { msg_type: 'text', content: { text: text } }).catch((e) => {
+      this.logger.error('Error sending lark message', e)
+    })
+  }
+
+  poolConnected(): void {
+    this.sendText('Successfully connected to node')
+  }
+
+  poolDisconnected(): void {
+    this.sendText('Disconnected from node unexpectedly. Reconnecting.')
+  }
+
+  poolSubmittedBlock(hash: Buffer, hashRate: number, clients: number): void {
+    this.sendText(
+      `Block \`${hash.toString('hex')}\` submitted successfully! ${FileUtils.formatHashRate(
+        hashRate,
+      )}/s with ${clients} miners`,
+    )
+  }
+
+  poolPayoutSuccess(
+    payoutId: number,
+    transactionHashHex: string,
+    receives: { publicAddress: string; amount: string; memo: string }[],
+    totalShareCount: number,
+  ): void {
+    const total = receives.reduce((m, c) => BigInt(c.amount) + m, BigInt(0))
+
+    this.sendText(
+      `Successfully paid out ${totalShareCount} shares to ${
+        receives.length
+      } users for ${displayIronAmountWithCurrency(
+        Number(oreToIron(Number(total.toString()))),
+        false,
+      )} in transaction \`${transactionHashHex}\` (${payoutId})`,
+    )
+  }
+
+  poolPayoutError(error: unknown): void {
+    this.sendText(
+      `Error while sending payout transaction: ${ErrorUtils.renderError(error, true)}`,
+    )
+  }
+}

--- a/ironfish/src/mining/poolShares.ts
+++ b/ironfish/src/mining/poolShares.ts
@@ -8,6 +8,7 @@ import { BigIntUtils } from '../utils/bigint'
 import { MapUtils } from '../utils/map'
 import { SetTimeoutToken } from '../utils/types'
 import { Discord } from './discord'
+import { Lark } from './lark'
 import { DatabaseShare, PoolDatabase } from './poolDatabase'
 
 export class MiningPoolShares {
@@ -15,6 +16,7 @@ export class MiningPoolShares {
   readonly config: Config
   readonly logger: Logger
   readonly discord: Discord | null
+  readonly lark: Lark | null
 
   private readonly db: PoolDatabase
   private enablePayouts: boolean
@@ -32,6 +34,7 @@ export class MiningPoolShares {
     config: Config
     logger?: Logger
     discord?: Discord
+    lark?: Lark
     enablePayouts?: boolean
   }) {
     this.db = options.db
@@ -39,6 +42,7 @@ export class MiningPoolShares {
     this.config = options.config
     this.logger = options.logger ?? createRootLogger()
     this.discord = options.discord ?? null
+    this.lark = options.lark ?? null
     this.enablePayouts = options.enablePayouts ?? true
 
     this.poolName = this.config.get('poolName')
@@ -55,6 +59,7 @@ export class MiningPoolShares {
     config: Config
     logger?: Logger
     discord?: Discord
+    lark?: Lark
     enablePayouts?: boolean
   }): Promise<MiningPoolShares> {
     const db = await PoolDatabase.init({
@@ -67,6 +72,7 @@ export class MiningPoolShares {
       config: options.config,
       logger: options.logger,
       discord: options.discord,
+      lark: options.lark,
       enablePayouts: options.enablePayouts,
     })
   }
@@ -157,9 +163,17 @@ export class MiningPoolShares {
         transactionReceives,
         shareCounts.totalShares,
       )
+
+      this.lark?.poolPayoutSuccess(
+        payoutId,
+        transaction.content.hash,
+        transactionReceives,
+        shareCounts.totalShares,
+      )
     } catch (e) {
       this.logger.error('There was an error with the transaction', e)
       this.discord?.poolPayoutError(e)
+      this.lark?.poolPayoutError(e)
     }
   }
 


### PR DESCRIPTION
## Summary
Since Discord message may get blocked for some reasons. Lark as well as FeiShu (in China) provides better experience especially for Chinese miners.
This PR Add lark support for Ironfish Pool which implements same functionality as Discord, like disconnect report, payout report etc.
## Testing Plan

## Breaking Change

Is this a breaking change? If yes, add notes below on why this is breaking and
what additional work is required, if any.

```
[ ] Yes
[x] No
```
